### PR TITLE
Refactor for better prompt and tool description organization

### DIFF
--- a/examples/alert_triage_agent/src/aiq_alert_triage_agent/categorizer.py
+++ b/examples/alert_triage_agent/src/aiq_alert_triage_agent/categorizer.py
@@ -28,13 +28,15 @@ from aiq.data_models.component_ref import LLMRef
 from aiq.data_models.function import FunctionBaseConfig
 
 from . import utils
-from .prompts import PipelineNodePrompts
+from .prompts import CategorizerPrompts
 
 
 class CategorizerToolConfig(FunctionBaseConfig, name="categorizer"):
-    description: str = Field(default="This is a categorization tool used at the end of the pipeline.",
+    description: str = Field(default=CategorizerPrompts.TOOL_DESCRIPTION,
                              description="Description of the tool.")
     llm_name: LLMRef
+    prompt: str = Field(default=CategorizerPrompts.PROMPT,
+                        description="Main prompt for the categorization task.")
 
 
 def _extract_markdown_heading_level(report: str) -> str:
@@ -48,7 +50,7 @@ def _extract_markdown_heading_level(report: str) -> str:
 async def categorizer_tool(config: CategorizerToolConfig, builder: Builder):
     # Set up LLM and chain
     llm = await builder.get_llm(config.llm_name, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
-    prompt_template = ChatPromptTemplate([("system", PipelineNodePrompts.CATEGORIZER_PROMPT),
+    prompt_template = ChatPromptTemplate([("system", config.prompt),
                                           MessagesPlaceholder("msgs")])
     categorization_chain = prompt_template | llm
 

--- a/examples/alert_triage_agent/src/aiq_alert_triage_agent/hardware_check_tool.py
+++ b/examples/alert_triage_agent/src/aiq_alert_triage_agent/hardware_check_tool.py
@@ -24,15 +24,15 @@ from aiq.data_models.component_ref import LLMRef
 from aiq.data_models.function import FunctionBaseConfig
 
 from . import utils
-from .prompts import ToolReasoningLayerPrompts
+from .prompts import HardwareCheckPrompts
 
 
 class HardwareCheckToolConfig(FunctionBaseConfig, name="hardware_check"):
-    description: str = Field(
-        default=("This tool checks hardware health status using IPMI monitoring to detect power state, "
-                 "hardware degradation, and anomalies that could explain alerts. Args: host_id: str"),
-        description="Description of the tool for the agent.")
+    description: str = Field(default=HardwareCheckPrompts.TOOL_DESCRIPTION,
+                             description="Description of the tool.")
     llm_name: LLMRef
+    prompt: str = Field(default=HardwareCheckPrompts.PROMPT,
+                        description="Main prompt for the hardware check task.")
     offline_mode: bool = Field(default=True, description="Whether to run in offline model")
 
 
@@ -94,7 +94,7 @@ async def hardware_check_tool(config: HardwareCheckToolConfig, builder: Builder)
                 # Additional LLM reasoning layer on playbook output to provide a summary of the results
                 utils.log_header("LLM Reasoning", dash_length=50)
 
-                prompt = ToolReasoningLayerPrompts.HARDWARE_CHECK.format(input_data=monitoring_data)
+                prompt = config.prompt.format(input_data=monitoring_data)
 
                 # Get analysis from LLM
                 conclusion = await utils.llm_ainvoke(config, builder, prompt)

--- a/examples/alert_triage_agent/src/aiq_alert_triage_agent/host_performance_check_tool.py
+++ b/examples/alert_triage_agent/src/aiq_alert_triage_agent/host_performance_check_tool.py
@@ -23,15 +23,17 @@ from aiq.data_models.function import FunctionBaseConfig
 
 from . import utils
 from .playbooks import HOST_PERFORMANCE_CHECK_PLAYBOOK
-from .prompts import ToolReasoningLayerPrompts
+from .prompts import HostPerformanceCheckPrompts
 
 
 class HostPerformanceCheckToolConfig(FunctionBaseConfig, name="host_performance_check"):
-    description: str = Field(
-        default=("This is the Host Performance Check Tool. This tool retrieves CPU usage, memory usage, "
-                 "and hardware I/O usage details for a given host. Args: host_id: str"),
-        description="Description of the tool for the agent.")
+    description: str = Field(default=HostPerformanceCheckPrompts.TOOL_DESCRIPTION,
+                             description="Description of the tool.")
     llm_name: LLMRef
+    parsing_prompt: str = Field(default=HostPerformanceCheckPrompts.PARSING_PROMPT,
+                                description="Prompt for parsing the raw host performance data.")
+    analysis_prompt: str = Field(default=HostPerformanceCheckPrompts.ANALYSIS_PROMPT,
+                                 description="Prompt for analyzing the parsed host performance data.")
     offline_mode: bool = Field(default=True, description="Whether to run in offline model")
 
 
@@ -97,7 +99,7 @@ async def _parse_stdout_lines(config, builder, stdout_lines):
         # Join the list of lines into a single text block
         input_data = "\n".join(stdout_lines) if stdout_lines else ""
 
-        prompt = ToolReasoningLayerPrompts.HOST_PERFORMANCE_CHECK_PARSING.format(input_data=input_data)
+        prompt = config.parsing_prompt.format(input_data=input_data)
 
         response = await utils.llm_ainvoke(config=config, builder=builder, user_prompt=prompt)
     except Exception as e:
@@ -146,7 +148,7 @@ async def host_performance_check_tool(config: HostPerformanceCheckToolConfig, bu
             # Additional LLM reasoning layer on playbook output to provide a summary of the results
             utils.log_header("LLM Reasoning", dash_length=50)
 
-            prompt_template = ToolReasoningLayerPrompts.HOST_PERFORMANCE_CHECK_ANALYSIS.format(input_data=output)
+            prompt_template = config.analysis_prompt.format(input_data=output)
 
             conclusion = await utils.llm_ainvoke(config, builder, user_prompt=prompt_template)
 

--- a/examples/alert_triage_agent/src/aiq_alert_triage_agent/maintenance_check.py
+++ b/examples/alert_triage_agent/src/aiq_alert_triage_agent/maintenance_check.py
@@ -31,17 +31,17 @@ from aiq.data_models.component_ref import LLMRef
 from aiq.data_models.function import FunctionBaseConfig
 
 from . import utils
-from .prompts import PipelineNodePrompts
+from .prompts import MaintenanceCheckPrompts
 
 NO_ONGOING_MAINTENANCE_STR = "No ongoing maintenance found for the host."
 
 
 class MaintenanceCheckToolConfig(FunctionBaseConfig, name="maintenance_check"):
-    description: str = Field(
-        default=("Check if a host is under maintenance during the time of an alert to help determine "
-                 "if the alert can be deprioritized."),
-        description="Description of the tool for the agent.")
+    description: str = Field(default=MaintenanceCheckPrompts.TOOL_DESCRIPTION,
+                             description="Description of the tool.")
     llm_name: LLMRef
+    prompt: str = Field(default=MaintenanceCheckPrompts.PROMPT,
+                        description="Main prompt for the maintenance check task.")
     static_data_path: str | None = Field(
         default="examples/alert_triage_agent/data/maintenance_static_dataset.csv",
         description=(
@@ -167,12 +167,13 @@ def _get_active_maintenance(df: pd.DataFrame, host_id: str, alert_time: datetime
     return start_time_str, end_time_str
 
 
-def _summarize_alert(llm, alert, maintenance_start_str, maintenance_end_str):
+def _summarize_alert(llm, prompt_template, alert, maintenance_start_str, maintenance_end_str):
     """
     Generate a summary report for an alert when the affected host is under maintenance.
 
     Args:
         llm: The language model to use for generating the summary
+        prompt_template: The prompt template to use for generating the summary
         alert (dict): Dictionary containing the alert details
         maintenance_start_str (str): Start time of maintenance window in "YYYY-MM-DD HH:MM:SS" format
         maintenance_end_str (str): End time of maintenance window in "YYYY-MM-DD HH:MM:SS" format,
@@ -181,8 +182,8 @@ def _summarize_alert(llm, alert, maintenance_start_str, maintenance_end_str):
     Returns:
         str: A markdown-formatted report summarizing the alert and maintenance status
     """
-    sys_prompt = PipelineNodePrompts.MAINTENANCE_CHECK_PROMPT.format(maintenance_start_str=maintenance_start_str,
-                                                                     maintenance_end_str=maintenance_end_str)
+    sys_prompt = prompt_template.format(maintenance_start_str=maintenance_start_str,
+                                        maintenance_end_str=maintenance_end_str)
     prompt_template = ChatPromptTemplate([("system", sys_prompt), MessagesPlaceholder("msgs")])
     summarization_chain = prompt_template | llm
     alert_json_str = json.dumps(alert)
@@ -249,7 +250,13 @@ async def maintenance_check(config: MaintenanceCheckToolConfig, builder: Builder
         # maintenance info found, summarize alert and return a report (agent execution will be skipped)
         utils.logger.info("Host: [%s] is under maintenance according to the maintenance database", host)
 
-        report = _summarize_alert(llm, alert, maintenance_start_str, maintenance_end_str)
+        report = _summarize_alert(
+            llm=llm,
+            prompt_template=config.prompt,
+            alert=alert,
+            maintenance_start_str=maintenance_start_str,
+            maintenance_end_str=maintenance_end_str
+        )
 
         utils.log_footer()
         return report

--- a/examples/alert_triage_agent/src/aiq_alert_triage_agent/monitoring_process_check_tool.py
+++ b/examples/alert_triage_agent/src/aiq_alert_triage_agent/monitoring_process_check_tool.py
@@ -23,14 +23,15 @@ from aiq.data_models.function import FunctionBaseConfig
 
 from . import utils
 from .playbooks import MONITOR_PROCESS_CHECK_PLAYBOOK
-from .prompts import ToolReasoningLayerPrompts
+from .prompts import MonitoringProcessCheckPrompts
 
 
 class MonitoringProcessCheckToolConfig(FunctionBaseConfig, name="monitoring_process_check"):
-    description: str = Field(default=("This tool checks the status of critical monitoring processes and services "
-                                      "on a target host by executing system commands. Args: host_id: str"),
-                             description="Description of the tool for the agent.")
+    description: str = Field(default=MonitoringProcessCheckPrompts.TOOL_DESCRIPTION,
+                             description="Description of the tool.")
     llm_name: LLMRef
+    prompt: str = Field(default=MonitoringProcessCheckPrompts.PROMPT,
+                        description="Main prompt for the monitoring process check task.")
     offline_mode: bool = Field(default=True, description="Whether to run in offline model")
 
 
@@ -104,7 +105,7 @@ async def monitoring_process_check_tool(config: MonitoringProcessCheckToolConfig
             # Additional LLM reasoning layer on playbook output to provide a summary of the results
             utils.log_header("LLM Reasoning", dash_length=50)
 
-            prompt = ToolReasoningLayerPrompts.MONITORING_PROCESS_CHECK.format(input_data=output_for_prompt)
+            prompt = config.prompt.format(input_data=output_for_prompt)
 
             conclusion = await utils.llm_ainvoke(config, builder, prompt)
 

--- a/examples/alert_triage_agent/src/aiq_alert_triage_agent/network_connectivity_check_tool.py
+++ b/examples/alert_triage_agent/src/aiq_alert_triage_agent/network_connectivity_check_tool.py
@@ -25,15 +25,15 @@ from aiq.data_models.component_ref import LLMRef
 from aiq.data_models.function import FunctionBaseConfig
 
 from . import utils
-from .prompts import ToolReasoningLayerPrompts
+from .prompts import NetworkConnectivityCheckPrompts
 
 
 class NetworkConnectivityCheckToolConfig(FunctionBaseConfig, name="network_connectivity_check"):
-    description: str = Field(
-        default=("This tool checks network connectivity of a host by running ping and socket connection tests. "
-                 "Args: host_id: str"),
-        description="Description of the tool for the agent.")
+    description: str = Field(default=NetworkConnectivityCheckPrompts.TOOL_DESCRIPTION,
+                             description="Description of the tool.")
     llm_name: LLMRef
+    prompt: str = Field(default=NetworkConnectivityCheckPrompts.PROMPT,
+                        description="Main prompt for the network connectivity check task.")
     offline_mode: bool = Field(default=True, description="Whether to run in offline model")
 
 
@@ -106,8 +106,8 @@ async def network_connectivity_check_tool(config: NetworkConnectivityCheckToolCo
             # Additional LLM reasoning layer on playbook output to provide a summary of the results
             utils.log_header("LLM Reasoning", dash_length=50)
 
-            prompt = ToolReasoningLayerPrompts.NETWORK_CONNECTIVITY_CHECK.format(ping_data=ping_data,
-                                                                                 telnet_data=telnet_data)
+            prompt = config.prompt.format(ping_data=ping_data,
+                                          telnet_data=telnet_data)
             conclusion = await utils.llm_ainvoke(config, builder, prompt)
 
             utils.logger.debug(conclusion)

--- a/examples/alert_triage_agent/src/aiq_alert_triage_agent/prompts.py
+++ b/examples/alert_triage_agent/src/aiq_alert_triage_agent/prompts.py
@@ -56,9 +56,10 @@ You are a Triage Agent responsible for diagnosing and troubleshooting system ale
 - Analyze tool outputs before taking any additional action.
 - Stay concise, structured, and actionable."""
 
-
-class PipelineNodePrompts:
-    CATEGORIZER_PROMPT = """You will be given a system-generated alert triage report. Your job is to read the report carefully and determine the most likely root cause of the issue. Then, categorize the root cause into one of the following predefined categories:
+class CategorizerPrompts:
+    # Fixed node in the pipeline, not an agent tool. (no prompt engineering required for this tool description)
+    TOOL_DESCRIPTION = """This is a categorization tool used at the end of the pipeline."""  
+    PROMPT = """You will be given a system-generated alert triage report. Your job is to read the report carefully and determine the most likely root cause of the issue. Then, categorize the root cause into one of the following predefined categories:
 
 **Valid Categories**
 - `software`: The alert was triggered due to a malfunctioning or inactive monitoring service (e.g., Telegraf not running).
@@ -79,7 +80,10 @@ Ping and curl to the host both failed, and telnet to the monitored port timed ou
 - Base your categorization only on evidence presented in the report.
 - If no category clearly fits, default to `need_investigation`."""
 
-    MAINTENANCE_CHECK_PROMPT = """User will provide you with a system alert represented in JSON format. You know for a fact that there is maintenance happening for the host. Maintenance start time for this host is : [{maintenance_start_str}]; end time is: [{maintenance_end_str}] (end time empty means that there is not yet a set end time for the maintenance on the host)
+class MaintenanceCheckPrompts:
+    # Fixed node in the pipeline, not an agent tool. (no prompt engineering required for this tool description)
+    TOOL_DESCRIPTION = """Check if a host is under maintenance during the time of an alert to help determine if the alert can be deprioritized."""
+    PROMPT = """User will provide you with a system alert represented in JSON format. You know for a fact that there is maintenance happening for the host. Maintenance start time for this host is : [{maintenance_start_str}]; end time is: [{maintenance_end_str}] (end time empty means that there is not yet a set end time for the maintenance on the host)
 Generate a markdown report in the following format:
 
 ## Alert Summary
@@ -97,9 +101,9 @@ Generate a markdown report in the following format:
 ## Alert Status
 (can deprioritize the investigation of the alert, host under maintenance)"""
 
-
-class ToolReasoningLayerPrompts:
-    NETWORK_CONNECTIVITY_CHECK = """You are assisting with alert triage by checking the network connectivity status of a host. Use the outputs from `ping` and `telnet` commands to determine whether the host is reachable. If connectivity issues are detected, analyze the possible root causes and provide a structured summary of your findings.
+class NetworkConnectivityCheckPrompts:
+    TOOL_DESCRIPTION = """This tool checks network connectivity of a host by running ping and socket connection tests. Args: host_id: str"""
+    PROMPT = """You are assisting with alert triage by checking the network connectivity status of a host. Use the outputs from `ping` and `telnet` commands to determine whether the host is reachable. If connectivity issues are detected, analyze the possible root causes and provide a structured summary of your findings.
 
 Instructions:
 1. Interpret the `ping` and `telnet` results to assess host reachability.
@@ -120,7 +124,9 @@ Ping Output:
 Telnet Output:
 {telnet_data}"""
 
-    MONITORING_PROCESS_CHECK = """You are checking whether the telegraf service is running on the server. Use the monitoring output below to verify its status. If it’s not running, identify possible reasons and assess the impact.
+class MonitoringProcessCheckPrompts:
+    TOOL_DESCRIPTION = """This tool checks the status of critical monitoring processes and services on a target host by executing system commands. Args: host_id: str"""
+    PROMPT = """You are checking whether the telegraf service is running on the server. Use the monitoring output below to verify its status. If it’s not running, identify possible reasons and assess the impact.
 
 Instructions:
 1. Check if the telegraf process is present and active.
@@ -136,7 +142,10 @@ Format your response as a structured summary:
 Monitoring Output:
 {input_data}"""
 
-    HOST_PERFORMANCE_CHECK_PARSING = """You are given system performance data captured from a host. Your task is to extract and organize the information into a clean, structured JSON format. The input contains system details and performance metrics, such as CPU, memory, and disk I/O.
+
+class HostPerformanceCheckPrompts:
+    TOOL_DESCRIPTION = """This tool retrieves CPU usage, memory usage, and hardware I/O usage details for a given host. Args: host_id: str"""
+    PARSING_PROMPT = """You are given system performance data captured from a host. Your task is to extract and organize the information into a clean, structured JSON format. The input contains system details and performance metrics, such as CPU, memory, and disk I/O.
 
 Follow these instructions:
 
@@ -148,8 +157,7 @@ Follow these instructions:
 
 Here is the input data:
 {input_data}"""
-
-    HOST_PERFORMANCE_CHECK_ANALYSIS = """You are analyzing system metrics to assess CPU and memory usage. Use the output below to determine whether CPU or memory usage is abnormally high, identify which processes are consuming the most resources, and assess whether the usage patterns could explain a recent alert.
+    ANALYSIS_PROMPT = """You are analyzing system metrics to assess CPU and memory usage. Use the output below to determine whether CPU or memory usage is abnormally high, identify which processes are consuming the most resources, and assess whether the usage patterns could explain a recent alert.
 
 Instructions:
 1. Evaluate overall CPU and memory usage levels.
@@ -169,7 +177,9 @@ System Metrics Output:
 {input_data}
 """
 
-    HARDWARE_CHECK = """You are analyzing IPMI metrics to support host monitoring and alert triage. Use the provided IPMI output to assess overall system status. Your goals are to:
+class HardwareCheckPrompts:
+    TOOL_DESCRIPTION = """This tool checks hardware health status using IPMI monitoring to detect power state, hardware degradation, and anomalies that could explain alerts. Args: host_id: str"""
+    PROMPT = """You are analyzing IPMI metrics to support host monitoring and alert triage. Use the provided IPMI output to assess overall system status. Your goals are to:
 
 1. Determine the system's current power state.
 2. Identify any signs of hardware degradation or failure.
@@ -188,9 +198,9 @@ Observed Anomalies: [List any irregularities or warning signs]
 Possible Cause of Alert: [e.g., hardware issue, thermal spike, power fluctuation, no clear issue]
 Next Steps: [Recommended actions or checks for further triage]"""
 
-
-class TelemetryMetricsAnalysisPrompts:
-    AGENT = """You arg a helpful alert triage assistant. Your task is to investigate an alert that was just triggered on a specific host. You will be given two inputs:
+class TelemetryMetricsAnalysisAgentPrompts:
+    TOOL_DESCRIPTION = """This is a telemetry metrics tool used to monitor remotely collected telemetry data. It checks server heartbeat data to determine whether the server is up and running and analyzes CPU usage patterns over the past 14 days to identify potential CPU issues. Args: host_id: str, alert_type: str"""
+    PROMPT = """You arg a helpful alert triage assistant. Your task is to investigate an alert that was just triggered on a specific host. You will be given two inputs:
 - `host_id`: the identifier of the host where the alert occurred.
 - `alert_type`: the type of alert that triggered.
 
@@ -210,11 +220,15 @@ Your response should include:
 - A concise summary of findings
 - Any insights or hypotheses that explain the alert"""
 
-    HOST_HEARTBEAT_CHECK = """The following is the telemetry metrics fetched for the host to see if it's been up and running (if result is empty, then the monitoring service on the host is down):
+class TelemetryMetricsHostHeartbeatCheckPrompts:
+    TOOL_DESCRIPTION = """This tool checks if a host's telemetry monitoring service is reporting heartbeat metrics. This tells us if the host is up and running. Args: host_id: str"""
+    PROMPT = """The following is the telemetry metrics fetched for the host to see if it's been up and running (if result is empty, then the monitoring service on the host is down):
 {data}
 Based on the data, summarize the fetched data and provide a conclusion of the host's running status."""
 
-    HOST_PERFORMANCE_CHECK = """You are an expert on analyzing CPU usage timeseries. Periodic usage peaks are expected benign system behavior.
+class TelemetryMetricsHostPerformanceCheckPrompts:
+    TOOL_DESCRIPTION = """This tool checks the performance of the host by analyzing the CPU usage timeseries. Args: host_id: str"""
+    PROMPT = """You are an expert on analyzing CPU usage timeseries. Periodic usage peaks are expected benign system behavior.
 User will provide data in the format of a list of lists, where each sublist contains two elements: timestamp and CPU usage percentage. User will also provide statistics on the timeseries. Write a markdown report about what was observed in the timeseries.
 
 Example format:

--- a/examples/alert_triage_agent/src/aiq_alert_triage_agent/telemetry_metrics_analysis_agent.py
+++ b/examples/alert_triage_agent/src/aiq_alert_triage_agent/telemetry_metrics_analysis_agent.py
@@ -30,18 +30,16 @@ from aiq.data_models.component_ref import LLMRef
 from aiq.data_models.function import FunctionBaseConfig
 
 from . import utils
-from .prompts import TelemetryMetricsAnalysisPrompts
+from .prompts import TelemetryMetricsAnalysisAgentPrompts
 
 
 class TelemetryMetricsAnalysisAgentConfig(FunctionBaseConfig, name="telemetry_metrics_analysis_agent"):
-    description: str = Field(default=("This is a telemetry metrics tool used to monitor remotely collected "
-                                      "telemetry data. It checks server heartbeat data to determine whether "
-                                      "the server is up and running and analyzes CPU usage patterns over "
-                                      "the past 14 days to identify potential CPU issues. Args: host_id: "
-                                      "str, alert_type: str"),
-                             description="Description of the tool for the agent.")
+    description: str = Field(default=TelemetryMetricsAnalysisAgentPrompts.TOOL_DESCRIPTION,
+                             description="Description of the tool for the triage agent.")
     tool_names: list[str] = []
     llm_name: LLMRef
+    prompt: str = Field(default=TelemetryMetricsAnalysisAgentPrompts.PROMPT,
+                        description="Main prompt for the telemetry metrics analysis agent.")
 
 
 @register_function(config_type=TelemetryMetricsAnalysisAgentConfig)
@@ -67,7 +65,7 @@ async def telemetry_metrics_analysis_agent_tool(config: TelemetryMetricsAnalysis
 
         # Define agent function that processes messages with LLM
         def telemetry_metrics_analysis_agent(state: MessagesState):
-            sys_msg = SystemMessage(content=TelemetryMetricsAnalysisPrompts.AGENT)
+            sys_msg = SystemMessage(content=config.prompt)
             return {"messages": [llm_n_tools.invoke([sys_msg] + state["messages"])]}
 
         # Build the agent execution graph

--- a/examples/alert_triage_agent/src/aiq_alert_triage_agent/telemetry_metrics_host_heartbeat_check_tool.py
+++ b/examples/alert_triage_agent/src/aiq_alert_triage_agent/telemetry_metrics_host_heartbeat_check_tool.py
@@ -23,15 +23,15 @@ from aiq.data_models.component_ref import LLMRef
 from aiq.data_models.function import FunctionBaseConfig
 
 from . import utils
-from .prompts import TelemetryMetricsAnalysisPrompts
+from .prompts import TelemetryMetricsHostHeartbeatCheckPrompts
 
 
 class TelemetryMetricsHostHeartbeatCheckToolConfig(FunctionBaseConfig, name="telemetry_metrics_host_heartbeat_check"):
-    description: str = Field(
-        default=("This tool checks if a host's telemetry monitoring service is reporting heartbeat metrics. "
-                 "This tells us if the host is up and running. Args: host_id: str"),
-        description="Description of the tool for the agent.")
+    description: str = Field(default=TelemetryMetricsHostHeartbeatCheckPrompts.TOOL_DESCRIPTION,
+                             description="Description of the tool.")
     llm_name: LLMRef
+    prompt: str = Field(default=TelemetryMetricsHostHeartbeatCheckPrompts.PROMPT,
+                        description="Main prompt for the telemetry metrics host heartbeat check task.")
     offline_mode: bool = Field(default=True, description="Whether to run in offline model")
     metrics_url: str = Field(default="", description="URL of the monitoring system")
 
@@ -70,7 +70,7 @@ async def telemetry_metrics_host_heartbeat_check_tool(config: TelemetryMetricsHo
             utils.log_header("LLM Reasoning", dash_length=30)
 
             conclusion = await utils.llm_ainvoke(
-                config, builder, user_prompt=TelemetryMetricsAnalysisPrompts.HOST_HEARTBEAT_CHECK.format(data=data))
+                config, builder, user_prompt=config.prompt.format(data=data))
 
             utils.logger.debug(conclusion)
             utils.log_footer(dash_length=50)

--- a/examples/alert_triage_agent/src/aiq_alert_triage_agent/telemetry_metrics_host_performance_check_tool.py
+++ b/examples/alert_triage_agent/src/aiq_alert_triage_agent/telemetry_metrics_host_performance_check_tool.py
@@ -29,15 +29,16 @@ from aiq.data_models.component_ref import LLMRef
 from aiq.data_models.function import FunctionBaseConfig
 
 from . import utils
-from .prompts import TelemetryMetricsAnalysisPrompts
+from .prompts import TelemetryMetricsHostPerformanceCheckPrompts
 
 
 class TelemetryMetricsHostPerformanceCheckToolConfig(FunctionBaseConfig,
                                                      name="telemetry_metrics_host_performance_check"):
-    description: str = Field(default=("This tool checks the performance of the host by analyzing the CPU "
-                                      "usage timeseries. Args: host_id: str"),
-                             description="Description of the tool for the agent.")
+    description: str = Field(default=TelemetryMetricsHostPerformanceCheckPrompts.TOOL_DESCRIPTION,
+                             description="Description of the tool.")
     llm_name: LLMRef
+    prompt: str = Field(default=TelemetryMetricsHostPerformanceCheckPrompts.PROMPT,
+                        description="Main prompt for the telemetry metrics host performance check task.")
     offline_mode: bool = Field(default=True, description="Whether to run in offline model")
     metrics_url: str = Field(default="", description="URL of the monitoring system")
 
@@ -163,7 +164,7 @@ async def telemetry_metrics_host_performance_check_tool(config: TelemetryMetrics
                 config,
                 builder,
                 user_prompt=data_input,
-                system_prompt=TelemetryMetricsAnalysisPrompts.HOST_PERFORMANCE_CHECK,
+                system_prompt=config.prompt,
             )
             utils.logger.debug(conclusion)
             utils.log_footer(dash_length=50)

--- a/examples/alert_triage_agent/tests/test_host_performance_check_tool.py
+++ b/examples/alert_triage_agent/tests/test_host_performance_check_tool.py
@@ -15,9 +15,10 @@
 
 import json
 from unittest.mock import patch
+from unittest.mock import MagicMock
 
 from aiq_alert_triage_agent.host_performance_check_tool import _parse_stdout_lines
-from aiq_alert_triage_agent.prompts import ToolReasoningLayerPrompts
+from aiq_alert_triage_agent.prompts import HostPerformanceCheckPrompts
 
 EXAMPLE_CPU_USAGE_OUTPUT = """
 03:45:00 PM  CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle
@@ -111,13 +112,17 @@ async def test_parse_stdout_lines_success():
     # Test data
     test_stdout_lines = [EXAMPLE_CPU_USAGE_OUTPUT, EXAMPLE_MEMORY_USAGE_OUTPUT, EXAMPLE_DISK_IO_OUTPUT]
 
+    # Create mock config with parsing_prompt
+    mock_config = MagicMock()
+    mock_config.parsing_prompt = HostPerformanceCheckPrompts.PARSING_PROMPT
+
     # Mock the LLM response
     with patch('aiq_alert_triage_agent.utils.llm_ainvoke') as mock_llm:
         mock_llm.return_value = EXAMPLE_LLM_PARSED_OUTPUT
 
         # Call the function
         result = await _parse_stdout_lines(
-            config=None,  # unused, mocked
+            config=mock_config,
             builder=None,  # unused, mocked
             stdout_lines=test_stdout_lines)
 
@@ -131,7 +136,7 @@ async def test_parse_stdout_lines_success():
         assert 'builder' in call_args
         assert 'user_prompt' in call_args
         input_data = "\n".join(test_stdout_lines)
-        assert call_args['user_prompt'] == ToolReasoningLayerPrompts.HOST_PERFORMANCE_CHECK_PARSING.format(
+        assert call_args['user_prompt'] == HostPerformanceCheckPrompts.PARSING_PROMPT.format(
             input_data=input_data)
 
 
@@ -141,8 +146,12 @@ async def test_parse_stdout_lines_llm_error():
         mock_llm.side_effect = Exception("LLM error")
         mock_llm.return_value = None
 
+        # Create mock config with parsing_prompt
+        mock_config = MagicMock()
+        mock_config.parsing_prompt = HostPerformanceCheckPrompts.PARSING_PROMPT
+
         result = await _parse_stdout_lines(
-            config=None,  # unused, mocked
+            config=mock_config,
             builder=None,  # unused, mocked
             stdout_lines=["Some test output"])
 


### PR DESCRIPTION
This PR moves the default values of tool descriptions into `prompt.py` and the default prompts into the config objects, so all "prompt-engineerable" strings are tracked in a centralized file and also by the config for easier prompt engineering and version tracking.

Will redirect to the main AIQ repo once the [eval PR](https://github.com/NVIDIA/AIQToolkit/pull/344) is merged.